### PR TITLE
Refining Monthly and Weekly Active Users on the Metrics Dashboard

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/metrics/MetricsMonthly.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/metrics/MetricsMonthly.tsx
@@ -1,7 +1,7 @@
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import React, { FunctionComponent } from 'react';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
-import { MetricsMonthlyQuery } from './__generated__/MetricsMonthlyQuery.graphql';
+import { FilterGroup, MetricsMonthlyQuery, MetricsMonthlyQuery$variables } from './__generated__/MetricsMonthlyQuery.graphql';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetDifference from '../../../../components/dashboard/WidgetDifference';
@@ -75,17 +75,31 @@ const MetricsMonthly = ({
   lastPeriodStartDate.setMonth(now.getMonth() - 2);
   lastPeriodEndDate.setMonth(now.getMonth() - 1);
 
+  const filters: FilterGroup = {
+    mode: 'and',
+    filters: [
+      {
+        key: ['event_scope'],
+        values: ['login', 'logout'],
+        operator: 'not_eq',
+      },
+    ],
+    filterGroups: [],
+  };
+
   // Get the user logins for last month and this current month
-  const distributionParameters = [
+  const distributionParameters: MetricsMonthlyQuery$variables['distributionParameters'] = [
     {
       field: 'user_id',
       startDate: lastPeriodStartDate.toISOString(),
       endDate: lastPeriodEndDate.toISOString(),
+      filters,
     },
     {
       field: 'user_id',
       startDate: lastPeriodEndDate.toISOString(),
       endDate: now.toISOString(),
+      filters,
     },
   ];
 

--- a/opencti-platform/opencti-front/src/private/components/settings/metrics/MetricsMonthly.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/metrics/MetricsMonthly.tsx
@@ -80,7 +80,7 @@ const MetricsMonthly = ({
     filters: [
       {
         key: ['event_scope'],
-        values: ['Create', 'Update', 'Unauthorized'],
+        values: ["search", "analyze", "enrich", "import", "export", "read", "create", "delete", "download", "disseminate", "update"],
       },
     ],
     filterGroups: [],

--- a/opencti-platform/opencti-front/src/private/components/settings/metrics/MetricsMonthly.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/metrics/MetricsMonthly.tsx
@@ -80,8 +80,7 @@ const MetricsMonthly = ({
     filters: [
       {
         key: ['event_scope'],
-        values: ['login', 'logout'],
-        operator: 'not_eq',
+        values: ['Create', 'Update', 'Unauthorized'],
       },
     ],
     filterGroups: [],

--- a/opencti-platform/opencti-front/src/private/components/settings/metrics/MetricsMonthlyGraph.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/metrics/MetricsMonthlyGraph.tsx
@@ -1,7 +1,7 @@
 import { PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import React, { FunctionComponent } from 'react';
 import AuditsWidgetMultiLines from '../../common/audits/AuditsWidgetMultiLines';
-import { MetricsMonthlyQuery } from './__generated__/MetricsMonthlyQuery.graphql';
+import { FilterGroup, MetricsMonthlyQuery } from './__generated__/MetricsMonthlyQuery.graphql';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import { mauDataQuery } from './MetricsMonthly';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
@@ -75,6 +75,18 @@ const MetricsMonthlyGraph = ({
     // Date range is `i` months ago to `i+1` months ago
     startDate.setMonth(now.getMonth() - i);
     endDate.setMonth(now.getMonth() - i + 1);
+
+    const filters: FilterGroup = {
+      mode: 'and',
+      filters: [
+        {
+          key: ['event_scope'],
+          values: ['login', 'logout'],
+          operator: 'not_eq',
+        },
+      ],
+      filterGroups: [],
+    };
 
     distributionParameters.push({
       field: 'user_id',

--- a/opencti-platform/opencti-front/src/private/components/settings/metrics/MetricsMonthlyGraph.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/metrics/MetricsMonthlyGraph.tsx
@@ -76,7 +76,7 @@ const MetricsMonthlyGraph = ({
       filters: [
         {
           key: ['event_scope'],
-          values: ['Create', 'Update', 'Unauthorized'],
+          values: ["search", "analyze", "enrich", "import", "export", "read", "create", "delete", "download", "disseminate", "update"],
         },
       ],
       filterGroups: [],

--- a/opencti-platform/opencti-front/src/private/components/settings/metrics/MetricsMonthlyGraph.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/metrics/MetricsMonthlyGraph.tsx
@@ -7,21 +7,16 @@ import { mauDataQuery } from './MetricsMonthly';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import { useFormatter } from '../../../../components/i18n';
+import { auditsDistributionParameters } from './__generated__/AuditsWeeklyQuery.graphql';
 
 /**
  * This file exports a graph widget showing unique user activity over a given
- * number of months. Defaults to a 6-month rolling range.
+ * number of months. Defa`ults to a 6-month rolling range.
  */
-
-type auditsDistributionParameter = {
-  field: string,
-  startDate: string,
-  endDate: string,
-};
 
 interface MetricsMonthlyGraphComponentProps {
   queryRef: PreloadedQuery<MetricsMonthlyQuery>,
-  dateRanges: auditsDistributionParameter[],
+  dateRanges: auditsDistributionParameters[],
 }
 
 const MetricsMonthlyGraphComponent: FunctionComponent<
@@ -64,7 +59,7 @@ const MetricsMonthlyGraph = ({
 }) => {
   const now = new Date();
   now.setHours(23, 59, 59, 999);
-  const distributionParameters: auditsDistributionParameter[] = [];
+  const distributionParameters: auditsDistributionParameters[] = [];
 
   // Create rolling date ranges for specified number of months
   for (let i = months; i > 0; i -= 1) {
@@ -81,8 +76,7 @@ const MetricsMonthlyGraph = ({
       filters: [
         {
           key: ['event_scope'],
-          values: ['login', 'logout'],
-          operator: 'not_eq',
+          values: ['Create', 'Update', 'Unauthorized'],
         },
       ],
       filterGroups: [],
@@ -92,6 +86,7 @@ const MetricsMonthlyGraph = ({
       field: 'user_id',
       startDate: startDate.toISOString(),
       endDate: endDate.toISOString(),
+      filters,
     });
   }
 

--- a/opencti-platform/opencti-front/src/private/components/settings/metrics/MetricsWeekly.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/metrics/MetricsWeekly.tsx
@@ -6,7 +6,7 @@ import Loader, { LoaderVariant } from '../../../../components/Loader';
 import WidgetDifference from '../../../../components/dashboard/WidgetDifference';
 import { useFormatter } from '../../../../components/i18n';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
-import { MetricsWeeklyQuery } from './__generated__/MetricsWeeklyQuery.graphql';
+import { FilterGroup, MetricsWeeklyQuery } from './__generated__/MetricsWeeklyQuery.graphql';
 import { metricsGraphqlQueryUser } from './metrics.d';
 
 export const wauDataQuery = graphql`
@@ -82,17 +82,30 @@ const MetricsWeekly = ({
   const lastPeriodStartDate = new Date(startOfWeek);
   lastPeriodStartDate.setDate(lastPeriodStartDate.getDate() - 7);
 
+  const filters: FilterGroup = {
+    mode: 'and',
+    filters: [
+      {
+        key: ['event_scope'],
+        values: ['Create', 'Update', 'Unauthorized'],
+      },
+    ],
+    filterGroups: [],
+  };
+
   // Get the user logins for last month and this current month
   const distributionParameters = [
     {
       field: 'user_id',
       startDate: lastPeriodStartDate.toISOString(),
       endDate: lastPeriodEndDate.toISOString(),
+      filters,
     },
     {
       field: 'user_id',
       startDate: lastPeriodEndDate.toISOString(),
       endDate: now.toISOString(),
+      filters,
     },
   ];
 

--- a/opencti-platform/opencti-front/src/private/components/settings/metrics/MetricsWeekly.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/metrics/MetricsWeekly.tsx
@@ -87,7 +87,7 @@ const MetricsWeekly = ({
     filters: [
       {
         key: ['event_scope'],
-        values: ['Create', 'Update', 'Unauthorized'],
+        values: ["search", "analyze", "enrich", "import", "export", "read", "create", "delete", "download", "disseminate", "update"],
       },
     ],
     filterGroups: [],

--- a/opencti-platform/opencti-front/src/private/components/settings/metrics/MetricsWeeklyGraph.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/metrics/MetricsWeeklyGraph.tsx
@@ -101,7 +101,7 @@ const MetricsWeeklyGraph = ({
     filters: [
       {
         key: ['event_scope'],
-        values: ['Create', 'Update', 'Unauthorized'],
+        values: ["search", "analyze", "enrich", "import", "export", "read", "create", "delete", "download", "disseminate", "update"],
       },
     ],
     filterGroups: [],

--- a/opencti-platform/opencti-front/src/private/components/settings/metrics/MetricsWeeklyGraph.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/metrics/MetricsWeeklyGraph.tsx
@@ -3,10 +3,12 @@ import { PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import AuditsWidgetMultiLines from '../../common/audits/AuditsWidgetMultiLines';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
-import { MetricsWeeklyQuery } from './__generated__/MetricsWeeklyQuery.graphql';
+import { FilterGroup, MetricsWeeklyQuery } from './__generated__/MetricsWeeklyQuery.graphql';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import { wauDataQuery } from './MetricsWeekly';
 import { useFormatter } from '../../../../components/i18n';
+import { auditsDistributionParameters } from './__generated__/AuditsWeeklyQuery.graphql';
+
 /**
  * This file exports a graph widget showing unique user activity over a given
  * number of weeks. Defaults to a 6-week rolling range, monday start-of-week.
@@ -47,15 +49,9 @@ const getWeekRangesVariables = (weekStartDay = 'Monday', numWeeks = 6) => {
   return results;
 };
 
-type auditsDistributionParameter = {
-  field: string,
-  startDate: string,
-  endDate: string,
-};
-
 interface MetricsWeeklyGraphComponentProps {
   queryRef: PreloadedQuery<MetricsWeeklyQuery>,
-  dateRanges: auditsDistributionParameter[],
+  dateRanges: auditsDistributionParameters[],
 }
 
 const MetricsWeeklyGraphComponent: FunctionComponent<
@@ -96,15 +92,27 @@ MetricsWeeklyGraphComponentProps
 const MetricsWeeklyGraph = ({
   weeks = 6,
 }) => {
-  const distributionParameters: auditsDistributionParameter[] = [];
+  const distributionParameters: auditsDistributionParameters[] = [];
 
   const weeksDates = getWeekRangesVariables(undefined, weeks);
+
+  const filters: FilterGroup = {
+    mode: 'and',
+    filters: [
+      {
+        key: ['event_scope'],
+        values: ['Create', 'Update', 'Unauthorized'],
+      },
+    ],
+    filterGroups: [],
+  };
 
   for (const weekDatePair of weeksDates) {
     distributionParameters.push({
       field: 'user_id',
       startDate: weekDatePair.startDate.toISOString(),
       endDate: weekDatePair.endDate.toISOString(),
+      filters,
     });
   }
 


### PR DESCRIPTION
### Proposed changes

* Refined Monthly Active Users Count to not include logins/logouts on Metrics Dashboard
* Refined Monthly Active Users Graph to not include logins/logouts on Metrics Dashboard
* Refined Weekly Active Users Count to not include logins/logouts on Metrics Dashboard
* Refined Weekly Active Users Graph to not include logins/logouts on Metrics Dashboard

### Related issues
*

### Checklist


- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments
